### PR TITLE
Fix/pm2

### DIFF
--- a/lib/api/start_gateway.js
+++ b/lib/api/start_gateway.js
@@ -1,4 +1,5 @@
-const ProcessManager = require(__dirname+'/../processes/process_manager.js');
+var path       = require('path');
+var Supervisor = require(path.join(__dirname,'/../processes/supervisor'));
 
 /**
  * @function startGateway
@@ -8,9 +9,7 @@ const ProcessManager = require(__dirname+'/../processes/process_manager.js');
  */
 
 function startGateway() {
-  console.log('Starting Gatewayd using PM2');
-  var processManager = new ProcessManager();
-  processManager.start();
+  return new Supervisor().start();
 }
 
 module.exports = startGateway;

--- a/lib/api/stop_gateway.js
+++ b/lib/api/stop_gateway.js
@@ -1,12 +1,12 @@
-var ProcessManager = require(__dirname+'/../processes/process_manager.js');
+var path       = require('path');
+var Supervisor = require(path.join(__dirname,'/../processes/supervisor'));
+
 /**
  * @function stopGateway
  * @description Halts all pocesses.
- * @param opts
  */
 function stopGateway() {
-  var processManager = new ProcessManager();
-  processManager.stop();
+  return new Supervisor().stop();
 }
 
 module.exports = stopGateway;

--- a/lib/processes/process_set.js
+++ b/lib/processes/process_set.js
@@ -1,23 +1,28 @@
+var path = require('path')
+
+function processPath(name) {
+  return path.join(__dirname, '/../../processes/'+name+'.js')
+}
 
 function ProcessSet() {
   this.processes = {};
-  this.processes[__dirname + '/../../processes/deposits.js'] = 1;
-  this.processes[__dirname + '/../../processes/withdrawals.js'] = 1;
-  this.processes[__dirname + '/../../processes/server.js'] = 1;
-  this.processes[__dirname + '/../../processes/incoming.js'] = 1;
-  this.processes[__dirname + '/../../processes/outgoing.js'] = 1;
+  this.processes[processPath('deposits')]    = true;
+  this.processes[processPath('withdrawals')] = true;
+  this.processes[processPath('server')]      = true;
+  this.processes[processPath('incoming')]    = true;
+  this.processes[processPath('outgoing')]    = true;
 }
 
 ProcessSet.prototype = {
   constructor: ProcessSet,
 
-  add: function(path) {
-    this.processes[path] = 1;
+  add: function(name) {
+    this.processes[processPath(name)] = true;
     return this.processes;
   },
 
-  remove: function(path) {
-    delete this.processes[path];
+  remove: function(name) {
+    delete this.processes[processPath(name)];
     return this.processes;
   },
 

--- a/lib/processes/process_set.js
+++ b/lib/processes/process_set.js
@@ -1,7 +1,7 @@
-var path = require('path')
+var path = require('path');
 
 function processPath(name) {
-  return path.join(__dirname, '/../../processes/'+name+'.js')
+  return path.join(__dirname, '/../../processes/'+name+'.js');
 }
 
 function ProcessSet() {

--- a/lib/processes/supervisor.js
+++ b/lib/processes/supervisor.js
@@ -1,0 +1,49 @@
+var Promise    = require('bluebird');
+var pm2        = require('pm2');
+pm2.connect    = Promise.promisify(pm2.connect);
+pm2.disconnect = Promise.promisify(pm2.disconnect);
+pm2.start      = Promise.promisify(pm2.start);
+pm2.kill       = Promise.promisify(pm2.killDaemon);
+
+var processSet = require(__dirname+'/index.js');
+
+function parseNameFromPath(path) {
+  return 'gatewayd:'+path.split('/').pop().replace('.js', '');
+}
+
+function Supervisor() {}
+
+Supervisor.prototype.start = function() {
+  return new Promise(function(resolve, reject) {
+    var processes;
+    return pm2.connect()
+      .then(function() {
+        return Promise.map(processSet.toArray(), function(path) {
+          return pm2.start(path, { name: parseNameFromPath(path) });
+        });
+      })
+      .then(function(started) {
+        processes = started;
+        return pm2.disconnect();
+      })
+      .then(function() {
+        resolve(processes);
+      })
+      .error(function(error) {
+        pm2.disconnect().then(function() {
+          reject(error);
+        })
+        .error(reject);
+      });
+  });
+};
+
+Supervisor.prototype.stop = function() {
+  return pm2.connect()
+    .then(function() {
+      return pm2.kill();
+    });
+};
+
+module.exports = Supervisor;
+

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "passport": "",
     "passport-http": "",
     "pg": "^3.0.3",
+    "pm2": "^0.12.3",
     "request": "",
     "require-all": "",
     "require-all-to-camel": "^1.0.0",

--- a/test/processes/pm2.js
+++ b/test/processes/pm2.js
@@ -1,0 +1,47 @@
+var path       = require('path')
+var Promise    = require('bluebird')
+var pm2        = Promise.promisifyAll(require('pm2'))
+var Supervisor = require(path.join(__dirname, '/../../lib/processes/supervisor'))
+var gatewayd   = require(path.join(__dirname, '/../../'))
+var assert     = require('assert')
+
+describe('Starting Gatewayd processes with PM2', function() {
+
+  before(function() {
+    supervisor = new Supervisor()
+  });
+
+  it('should be able to remove or add processes', function() {
+    assert.strictEqual(gatewayd.processes.toArray().length, 5)
+
+    gatewayd.processes.remove('withdrawals')
+    gatewayd.processes.remove('deposits')
+
+    assert.strictEqual(gatewayd.processes.toArray().length, 3)
+
+    gatewayd.processes.add('withdrawals')
+    assert.strictEqual(gatewayd.processes.toArray().length, 4)
+
+    gatewayd.processes.add('deposits')
+    assert.strictEqual(gatewayd.processes.toArray().length, 5)
+  })
+
+  it('should first start the pm2 daemon then all 5 processes', function(done) {
+
+    gatewayd.processes.remove('withdrawals')
+    gatewayd.processes.remove('deposits')
+
+    supervisor.start()
+      .then(function(processes) {
+        assert.strictEqual(processes.length, 3)
+        done()
+      })
+      .error(done)
+  })
+
+  after(function(done) {
+    supervisor.stop()
+    setTimeout(done, 1000)
+  })
+})
+


### PR DESCRIPTION
Use the PM2 node.js api rather than `exec` to spawn new child processes. Now waits until pm2 is fully connected before starting processes.